### PR TITLE
Added ContentID to Attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `postmark-inbound` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added the parsing and storing of the `ContentID` field in attachments
+
 ## [v1.0.1] - 2023-01-05
 
 ### Added

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -8,7 +8,8 @@ class Attachment
         public readonly string $name,
         public readonly string $content,
         public readonly string $contentType,
-        public readonly int $contentLength
+        public readonly int $contentLength,
+        public readonly ?string $contentId = null
     ) {
     }
 }

--- a/src/Inbound.php
+++ b/src/Inbound.php
@@ -63,7 +63,8 @@ class Inbound
             $attachmentData['Name'],
             $attachmentData['Content'],
             $attachmentData['ContentType'],
-            $attachmentData['ContentLength']
+            $attachmentData['ContentLength'],
+            $attachmentData['ContentID'] ?? null
         );
 
         $jsonToHeader = static fn (array $headerData): Header => new Header(

--- a/tests/InboundTest.php
+++ b/tests/InboundTest.php
@@ -78,13 +78,15 @@ class InboundTest extends TestCase
                 "myimage.png",
                 "[BASE64-ENCODED CONTENT]",
                 "image/png",
-                4096
+                4096,
+                "myimage.png@01CE7342.75E71F80"
             ),
             new Attachment(
                 "mypaper.doc",
                 "[BASE64-ENCODED CONTENT]",
                 "application/msword",
-                16384
+                16384,
+                ''
             ),
         ], $message->getAttachments());
 


### PR DESCRIPTION
Postmark offers the ContentID field for each element in the attachments array:

![image](https://github.com/user-attachments/assets/92b0697b-926e-4362-a153-0346ef0fb524)

> The picture above is taken from an actual Postmark JSON

This field is used primarily for embedded images in the HTML message body. To support their parsing in target applications, this PR adds the optional `contentId` field to attachments.

## A Note on Field Presence

Theoretically, the ContentID field only makes sense for images or other embeddable attachments. According to our tests however, Gmail sets the ContentID on non-image attachments as well:

![image](https://github.com/user-attachments/assets/c3ea97a6-fc0d-4814-a665-39e654e1f31d)

Outlook 365, on the other hand leaves it empty:

![image](https://github.com/user-attachments/assets/38bd25e4-a2fa-4c1c-b6ee-9c07739fe7a8)


Therefore, it's not 100% sure that every attachment has a ContentID, so the code in this PR treats it as optional and not necessarily present. In such cases, the value of the field in the DTO will be `null`. Empty strings will be kept as-is

